### PR TITLE
fix(): Comment out exception when extra fields are found in from_json_obj 

### DIFF
--- a/avrogen/avrojson.py
+++ b/avrogen/avrojson.py
@@ -354,6 +354,9 @@ class AvroJsonConverter(object):
                     else:
                         raise ValueError(f'{readers_schema.fullname} is missing required field: {field.name}')
             result[field.name] = field_value
-        if input_keys:
-            raise ValueError(f'{readers_schema.fullname} contains extra fields: {input_keys}')
+        # John Joyce - 6/2/2022
+        # Be forgiving of extra fields - do not throw if there are fields that we do not know about.
+        # This is because we do not have the true writer schema at the time of binding an object from json.
+        # if input_keys:
+        #    raise ValueError(f'{readers_schema.fullname} contains extra fields: {input_keys}')
         return self._instantiate_record(result, writers_schema, readers_schema)

--- a/avrogen/avrojson.py
+++ b/avrogen/avrojson.py
@@ -329,7 +329,7 @@ class AvroJsonConverter(object):
             return self._make_type(self.schema_types[readers_name], decoded_record)
         return decoded_record
 
-    def _record_from_json(self, json_obj, writers_schema, readers_schema):
+    def _record_from_json(self, json_obj, writers_schema, readers_schema, fail_on_extra_fields=False):
         writer_fields = writers_schema.fields_dict
 
         input_keys = set(json_obj.keys())
@@ -354,9 +354,7 @@ class AvroJsonConverter(object):
                     else:
                         raise ValueError(f'{readers_schema.fullname} is missing required field: {field.name}')
             result[field.name] = field_value
-        # John Joyce - 6/2/2022
-        # Be forgiving of extra fields - do not throw if there are fields that we do not know about.
-        # This is because we do not have the true writer schema at the time of binding an object from json.
-        # if input_keys:
-        #    raise ValueError(f'{readers_schema.fullname} contains extra fields: {input_keys}')
+        if input_keys and fail_on_extra_fields:
+            # only throw errors if there are fields that we do not know about and fail_on_extra_fields is set to True
+            raise ValueError(f'{readers_schema.fullname} contains extra fields: {input_keys}')
         return self._instantiate_record(result, writers_schema, readers_schema)


### PR DESCRIPTION
When we deserialize from json into our Avro objects, we use the from_json_obj method. 

Currently if there are fields that do not exist in the avro schema generated and baked into the classes, this method will raise an exception.

This effectively makes our auto-generated python classes forward incompatible with any changes to the writer schema. This change addresses this by ignoring unknown fields!