### PR TITLE
Add schema class naming strategy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ else:
 
 setup(
     name="avro-gen3",
-    version="0.7.6",
+    version="0.7.7",
     description="Avro record class and specific record reader generator",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/generator_tests.py
+++ b/tests/generator_tests.py
@@ -205,6 +205,34 @@ class GeneratorTestCase(unittest.TestCase):
         self.assertTrue(hasattr(kop, 'known'))
         self.assertTrue(hasattr(kop, 'data'))
 
+    def test_tweet_custom(self):
+        def class_naming_strategy(fullname):
+            return 'Custom' + fullname.split('.')[-1]
+
+        schema_json = self.read_schema('tweet.json')
+        avrogen.schema.write_schema_files(schema_json, self.output_dir, class_naming_strategy=class_naming_strategy)
+        root_module, _ = self.load_gen(self.test_name)
+        twitter_ns = importlib.import_module('.com.bifflabs.grok.model.twitter.avro', self.test_name)
+        common_ns = importlib.import_module('.com.bifflabs.grok.model.common.avro', self.test_name)
+
+        self.assertTrue(hasattr(twitter_ns, 'CustomAvroTweet'))
+        self.assertTrue(hasattr(twitter_ns, 'CustomAvroTweetMetadata'))
+        self.assertTrue(hasattr(common_ns, 'CustomAvroPoint'))
+        self.assertTrue(hasattr(common_ns, 'CustomAvroDateTime'))
+        self.assertTrue(hasattr(common_ns, 'CustomAvroKnowableOptionString'))
+        self.assertTrue(hasattr(common_ns, 'CustomAvroKnowableListString'))
+        self.assertTrue(hasattr(common_ns, 'CustomAvroKnowableBoolean'))
+        self.assertTrue(hasattr(common_ns, 'CustomAvroKnowableOptionPoint'))
+
+        self.assertIsNotNone(twitter_ns.CustomAvroTweet.construct_with_defaults())
+        self.assertIsNotNone(twitter_ns.CustomAvroTweetMetadata.construct_with_defaults())
+        self.assertIsNotNone(common_ns.CustomAvroPoint.construct_with_defaults())
+        self.assertIsNotNone(common_ns.CustomAvroDateTime.construct_with_defaults())
+        self.assertIsNotNone(common_ns.CustomAvroKnowableOptionString.construct_with_defaults())
+        self.assertIsNotNone(common_ns.CustomAvroKnowableListString.construct_with_defaults())
+        self.assertIsNotNone(common_ns.CustomAvroKnowableBoolean.construct_with_defaults())
+        self.assertIsNotNone(common_ns.CustomAvroKnowableOptionString.construct_with_defaults())
+
     def test_logical(self):
         schema_json = self.read_schema('logical_types.json')
         avrogen.schema.write_schema_files(schema_json, self.output_dir, use_logical_types=True)


### PR DESCRIPTION
Hello, thank you very much for adding Python 3 support for this project!

The use case I've been working on has a schema that requires me to customize the names of the generated classes to work properly.

This PR adds an optional `class_naming_strategy` parameter to the `generate_schema` schema function (and subsequent relevant calls) that receives another function to be used as the strategy for resolving the name of the class from the full name of the field.

Cheers! 🎉 