### PR TITLE
move enum docstrings below text (0.7.11)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install package
       run: |
         pip install -e '.'
-        pip install coverage
+        pip install coverage pytz
     - name: Test
       run: |
         python -m coverage run -m unittest discover -s ./tests -p '*_tests.py'

--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -458,9 +458,10 @@ def write_enum(enum, writer):
         writer.write('\n\n')
         symbolDocs = enum.other_props.get('symbolDocs', {})
         for field in enum.symbols:
-            if symbolDocs:
-                writer.write('\n')
+            # Docs for enum fields go _below_ the field.
+            writer.write('{name} = "{name}"\n'.format(name=field))
             if field in symbolDocs:
                 writer.write(f'"""{symbolDocs[field]}"""\n')
-            writer.write('{name} = "{name}"\n'.format(name=field))
+            if symbolDocs:
+                writer.write('\n')
         writer.write('\n')

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,5 @@ setup(
     install_requires=[
         "avro>=1.10",
         "six",
-        # tzlocal 5 uses zoneinfo instead of pytz. Eventually we should
-        # make the switch, but for now we'll stick with a version cap.
-        "tzlocal<5",
-        "pytz",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,9 @@ setup(
     install_requires=[
         "avro>=1.10",
         "six",
-        "tzlocal",
+        # tzlocal 5 uses zoneinfo instead of pytz. Eventually we should
+        # make the switch, but for now we'll stick with a version cap.
+        "tzlocal<5",
         "pytz",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ else:
 
 setup(
     name="avro-gen3",
-    version="0.7.10",
+    version="0.7.11",
     description="Avro record class and specific record reader generator",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/generator_tests.py
+++ b/tests/generator_tests.py
@@ -216,8 +216,6 @@ class GeneratorTestCase(unittest.TestCase):
 
         import decimal
         import datetime
-        import pytz
-        import tzlocal
 
         instance = LogicalTypesTest(
             decimalField=decimal.Decimal(1.0),
@@ -247,11 +245,11 @@ class GeneratorTestCase(unittest.TestCase):
         self.assertEqual(instance.timeMicrosFieldWithDefault, datetime.time(second=42))
 
         self.assertEqual(
-            tzlocal.get_localzone().localize(instance.timestampMicrosFieldWithDefault).astimezone(pytz.UTC),
-            datetime.datetime(1970, 1, 1, 0, 0, 42, tzinfo=pytz.UTC))
+            instance.timestampMicrosFieldWithDefault,
+            datetime.datetime(1970, 1, 1, 0, 0, 42, tzinfo=datetime.timezone.utc))
         self.assertEqual(
-            tzlocal.get_localzone().localize(instance.timestampMillisFieldWithDefault).astimezone(pytz.UTC),
-            datetime.datetime(1970, 1, 1, 0, 0, 42, tzinfo=pytz.UTC))
+            instance.timestampMillisFieldWithDefault,
+            datetime.datetime(1970, 1, 1, 0, 0, 42, tzinfo=datetime.timezone.utc))
 
     @unittest.skip("don't care about protocol tests")
     def test_simple_protocol(self):

--- a/tests/logical_tests.py
+++ b/tests/logical_tests.py
@@ -143,7 +143,7 @@ class LogicalTypeTest(unittest.TestCase):
 
         self.assertEqual(
             p.convert_back(test_schema2, test_schema2, p.convert(test_schema2, datetime.datetime(2016, 1, 1))),
-            datetime.datetime(2016, 1, 1))
+            datetime.datetime(2016, 1, 1, tzinfo=datetime.timezone.utc))
 
     def test_timestamp_millis(self):
         p = TimestampMillisLogicalTypeProcessor()
@@ -176,7 +176,7 @@ class LogicalTypeTest(unittest.TestCase):
 
         self.assertEqual(
             p.convert_back(test_schema2, test_schema2, p.convert(test_schema2, datetime.datetime(2016, 1, 1))),
-            datetime.datetime(2016, 1, 1))
+            datetime.datetime(2016, 1, 1, tzinfo=datetime.timezone.utc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Slack report: https://datahubspace.slack.com/archives/C029A3M079U/p1693507207686729

Also makes all timestamps utc and drops `lzlocal` from deps