### PR TITLE
fix: make to_obj() more efficient

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         avro-version: ["1.10.2", "1.11.0"]
 
     steps:

--- a/avrogen/dict_wrapper.py
+++ b/avrogen/dict_wrapper.py
@@ -12,7 +12,6 @@ class DictWrapper:
     _inner_dict: dict
 
     RECORD_SCHEMA: ClassVar[RecordSchema]
-    _json_converter: ClassVar["AvroJsonConverter"]
 
     def __init__(self):
         self._inner_dict = {}
@@ -43,17 +42,18 @@ class DictWrapper:
         return cls._construct({})
 
     @classmethod
-    def _get_json_converter(cls) -> "AvroJsonConverter":
-        # This attribute will be set by the AvroJsonConverter's init method.
-        return cls._json_converter
+    def _get_json_converter(cls, tuples: bool = False) -> "AvroJsonConverter":
+        import avrogen.avrojson
+
+        return avrogen.avrojson.get_global_json_converter(tuples)
 
     @classmethod
     def from_obj(cls: Type[TC], obj: dict, tuples: bool = False) -> TC:
-        conv = cls._get_json_converter().with_tuple_union(tuples)
+        conv = cls._get_json_converter(tuples=tuples)
         return conv.from_json_object(obj, cls.RECORD_SCHEMA)
 
     def to_obj(self, tuples: bool = False) -> dict:
-        conv = self._get_json_converter().with_tuple_union(tuples)
+        conv = self._get_json_converter(tuples=tuples)
         return conv.to_json_object(self, self.RECORD_SCHEMA)
 
     def to_avro_writable(self, fastavro: bool = False) -> dict:

--- a/avrogen/protocol.py
+++ b/avrogen/protocol.py
@@ -160,7 +160,8 @@ def generate_protocol(protocol_json, use_logical_types=False, custom_imports=Non
     writer.untab()
     writer.write('\n}\n')
 
-    writer.write('_json_converter = %s\n\n' % avro_json_converter)
+    writer.write('_json_converter = %s\n' % avro_json_converter)
+    writer.write('avrojson.set_global_json_converter(_json_converter)\n')
     value = main_out.getvalue()
     main_out.close()
     return value, schema_names, request_names

--- a/avrogen/schema.py
+++ b/avrogen/schema.py
@@ -83,7 +83,8 @@ def generate_schema(schema_json, use_logical_types=False, custom_imports=None, a
     writer.untab()
     writer.write('\n}\n\n')
 
-    writer.write(f'_json_converter = {avro_json_converter}\n\n')
+    writer.write(f'_json_converter = {avro_json_converter}\n')
+    writer.write('avrojson.set_global_json_converter(_json_converter)\n\n')
 
     value = main_out.getvalue()
     main_out.close()

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ else:
 
 setup(
     name="avro-gen3",
-    version="0.7.11",
+    version="0.7.12",
     description="Avro record class and specific record reader generator",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
We used to instantiate an instance of AvroJsonConverter every time .validate() or .to_obj() was called. Now, we just create each once globally and use them throughout.